### PR TITLE
Avoid many useless speech chunks in inference

### DIFF
--- a/simulstream/inference.py
+++ b/simulstream/inference.py
@@ -49,6 +49,8 @@ def process_audio(
         sample_rate (int): Audio sample rate (Hz).
         data (np.ndarray): Audio samples as int16 array.
     """
+    # speech_chunk_size is expressed in seconds, so the number of samples corresponding to
+    # one speech chunk is the following
     samples_per_chunk = int(
         sample_rate * message_processor.speech_processor.speech_chunk_size)
     i = 0


### PR DESCRIPTION
# Why is needed?

The current inference script uses a very small speech chunk size, which causes many useless loops, due to a wrong computation of the number of items corresponding to the speech chunk size configured in the speech processor to evaluate.


# What does the PR do?

Fixes speech chunk computation.

# How was the PR tested?

Manual runs.