### PR TITLE
[CI] Skip creation of virtual environments to avoid issues in docs building

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,25 +25,19 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install virtualenv
-          virtualenv venv
-          source venv/bin/activate
           pip install .[dev,eval]
 
       - name: Lint
         run: |
-          source venv/bin/activate
           flake8
 
       - name: Unit Tests
         run: |
-          source venv/bin/activate
           export IS_TESTING=true
           python -m unittest discover -s uts -p "*.py"
 
       - name: Build Sphinx HTML documentation
         run: |
-          source venv/bin/activate
           sphinx-build -b html docs/source docs/build
           zip -r docs.zip docs/build
 


### PR DESCRIPTION
The CI is currenlty failing due to a missing dependency in building sphinx docs. This happens because sphinx does not use the python from virtual environment.

To solve the issue, we can skip the creation of the virtual environment, ensuring the system level python has all the dependencies.

Closes #21 